### PR TITLE
Remove `text-white` from "Select a rhyme type"

### DIFF
--- a/app/lib/components/RhymeTypesRadioGroup.tsx
+++ b/app/lib/components/RhymeTypesRadioGroup.tsx
@@ -17,9 +17,7 @@ const RhymeTypesRadioGroup = ({
 }: IRhymeTypesRadioGroup) => {
     return (
         <div>
-            <h3 className="mb-3 text-white font-bold text-center">
-                Select a rhyme type
-            </h3>
+            <h3 className="mb-3 font-bold text-center">Select a rhyme type</h3>
             <ul className="w-48 text-sm font-medium text-gray-900 bg-slate-50 rounded-lg overflow-hidden">
                 <li className="w-full border-b border-gray-300 rounded-t-lg">
                     <div className="flex items-center ps-3">


### PR DESCRIPTION
The `text-white` class was causing text to be white when a computer is in light mode. This makes the text difficult to read.